### PR TITLE
Compile with RelWithDebInfo

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -7,7 +7,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 target_platform:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 # This file was generated automatically from conda-smithy. To update this configuration,
 # update the conda-forge.yml and/or the recipe/meta.yaml.
-# -*- mode: yaml -*-
+# -*- mode: jinja-yaml -*-
 
 version: 2
 

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -33,9 +33,9 @@ CONDARC
 
 
 mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Current build status
               <td>linux_64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17726&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hdbpp-es-feedstock?branchName=main&jobName=linux&configuration=linux_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hdbpp-es-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_" alt="variant">
                 </a>
               </td>
             </tr>

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-hdbpp--es-green.svg)](https://anaconda.org/conda-forge/hdbpp-es) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/hdbpp-es.svg)](https://anaconda.org/conda-forge/hdbpp-es) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/hdbpp-es.svg)](https://anaconda.org/conda-forge/hdbpp-es) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/hdbpp-es.svg)](https://anaconda.org/conda-forge/hdbpp-es) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-hdbpp--es--dbg-green.svg)](https://anaconda.org/conda-forge/hdbpp-es-dbg) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/hdbpp-es-dbg.svg)](https://anaconda.org/conda-forge/hdbpp-es-dbg) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/hdbpp-es-dbg.svg)](https://anaconda.org/conda-forge/hdbpp-es-dbg) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/hdbpp-es-dbg.svg)](https://anaconda.org/conda-forge/hdbpp-es-dbg) |
 
 Installing hdbpp-es
 ===================
@@ -62,16 +63,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `hdbpp-es` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `hdbpp-es, hdbpp-es-dbg` can be installed with `conda`:
 
 ```
-conda install hdbpp-es
+conda install hdbpp-es hdbpp-es-dbg
 ```
 
 or with `mamba`:
 
 ```
-mamba install hdbpp-es
+mamba install hdbpp-es hdbpp-es-dbg
 ```
 
 It is possible to list all of the versions of `hdbpp-es` available on your platform with `conda`:

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,3 +5,10 @@ cmake ${CMAKE_ARGS} \
 
 cmake --build build -v -j $CPU_COUNT
 cmake --build build --target install
+
+
+# Separate debugging symbols to create separate package
+${OBJCOPY} --only-keep-debug ${PREFIX}/bin/hdb++es-srv ${PREFIX}/bin/hdb++es-srv.dbg
+chmod 664 ${PREFIX}/bin/hdb++es-srv.dbg
+${OBJCOPY} --strip-debug ${PREFIX}/bin/hdb++es-srv
+${OBJCOPY} --add-gnu-debuglink=${PREFIX}/bin/hdb++es-srv.dbg ${PREFIX}/bin/hdb++es-srv

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,7 +1,7 @@
 cmake ${CMAKE_ARGS} \
-      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_BUILD_TYPE=RelWithDebInfo \
       -DLIBHDBPP_BACKEND=libhdbpp \
       -S . -B build
 
-cmake --build build -j $CPU_COUNT
+cmake --build build -v -j $CPU_COUNT
 cmake --build build --target install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 75f5ef639c840c76a098368198184bb06697b2fe232c2c0d5483dfc611e764de
 
 build:
-  number: 0
+  number: 1
   skip: true  # [not linux]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,9 @@ source:
 build:
   number: 1
   skip: true  # [not linux]
+  # Prevent hdb++es-srv.dbg to be modified
+  binary_relocation:
+    - bin/hdb++es-srv
 
 requirements:
   build:
@@ -30,6 +33,21 @@ requirements:
 test:
   commands:
     - hdb++es-srv --help 2>&1 | grep usage
+
+outputs:
+  - name: hdbpp-es
+    files:
+      - bin/hdb++es-srv
+
+  - name: hdbpp-es-dbg
+    requirements:
+      run:
+        - {{ pin_subpackage('hdbpp-es', exact=True) }}
+    files:
+      - bin/hdb++es-srv.dbg
+    test:
+      commands:
+        - test -f ${PREFIX}/bin/hdb++es-srv.dbg
 
 about:
   home: https://www.tango-controls.org


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

This will compile with "-O2 -g" instead of "-O3".
The binary will be about 9.2M instead of 681K, so that's not a big issue.

Having the debug info can be very useful in case of crash.

Update 20230111: Moved the debug symbols to a new package: hdbpp-es-dbg
